### PR TITLE
Do not exclude favicon.ico

### DIFF
--- a/recipe/contao.php
+++ b/recipe/contao.php
@@ -75,7 +75,6 @@ add('exclude', [
     '/web/app.php',
     '/web/app_dev.php',
     '/web/index.php',
-    '/web/favicon.ico',
     '/web/preview.php',
     '/web/robots.txt',
 ]);


### PR DESCRIPTION
Removing this, because the install-web-dir command does not add a favicon.ico anymore, and, not having a favicon.ico blows up my error log ("No route found for "GET /favicon.ico"")