### PR TITLE
Use actual domain when resetting OPcache

### DIFF
--- a/recipe/deploy.php
+++ b/recipe/deploy.php
@@ -127,12 +127,10 @@ task('deploy:clear_accelerator_clear', function () {
 task(
     'deploy:opcache_reset',
     static function () {
-        try {
-            $domain = get('domain') ?: get('hostname');
+        $domain = get('domain', get('hostname'));
 
-            run(
-                'cd {{current_path}} && echo "<?php opcache_reset();" > web/opcache.php && curl -L https://'.$domain.'/opcache.php && rm web/opcache.php'
-            );
-        } catch (ConfigurationException $e) {}
+        run(
+            'cd {{current_path}} && echo "<?php opcache_reset();" > web/opcache.php && curl -L https://'.$domain.'/opcache.php && rm web/opcache.php'
+        );
     }
 )->desc('Clear OPCache');

--- a/recipe/deploy.php
+++ b/recipe/deploy.php
@@ -123,12 +123,16 @@ task('deploy:clear_accelerator_clear', function () {
 })->desc('Clear accelerator cache');
 
 
-// Rest the OPcache (tasks deploy:clear_accelerator_clear and deploy:opcache_reset are interchangeable)
+// Reset the OPcache (tasks deploy:clear_accelerator_clear and deploy:opcache_reset are interchangeable)
 task(
     'deploy:opcache_reset',
     static function () {
-        run(
-            'cd {{current_path}} && echo "<?php opcache_reset();" > web/opcache.php && curl -L https://{{hostname}}/opcache.php && rm web/opcache.php'
-        );
+        try {
+            $domain = get('domain') ?: get('hostname');
+
+            run(
+                'cd {{current_path}} && echo "<?php opcache_reset();" > web/opcache.php && curl -L https://'.$domain.'/opcache.php && rm web/opcache.php'
+            );
+        } catch (ConfigurationException $e) {}
     }
 )->desc('Clear OPCache');


### PR DESCRIPTION
The config key 'domain' will be used to build the URL; fallback to 'hostname' if not configured/truthy.

see #13 