### PR TITLE
Switch to richardhj/contao-backup-manager

### DIFF
--- a/bootstrap/contao4-encore.php
+++ b/bootstrap/contao4-encore.php
@@ -62,6 +62,9 @@ set('rsync', function () {
     ];
 });
 
+// Recommended when using the database:backup task
+add('shared_dirs', ['backups']);
+
 /**
  * ===============================================================
  * Tasks

--- a/bootstrap/contao4-gulp.php
+++ b/bootstrap/contao4-gulp.php
@@ -62,6 +62,9 @@ set('rsync', function () {
     ];
 });
 
+// Recommended when using the database:backup task
+add('shared_dirs', ['backups']);
+
 /**
  * ===============================================================
  * Tasks

--- a/recipe/database.php
+++ b/recipe/database.php
@@ -13,7 +13,7 @@ use Deployer\Exception\RuntimeException;
 // Backup database
 task('database:backup', function () {
     try {
-        run('cd {{release_path}} && {{bin/composer}} show richardhj/contao-backup-manager');
+        run('cd {{release_path}} && {{bin/composer}} show backup-manager/symfony');
     } catch (RuntimeException $e) {
         writeln("\r\033[1A\033[32C … skipped");
 

--- a/recipe/database.php
+++ b/recipe/database.php
@@ -13,7 +13,7 @@ use Deployer\Exception\RuntimeException;
 // Backup database
 task('database:backup', function () {
     try {
-        run('cd {{release_path}} && {{bin/composer}} show backup-manager/symfony');
+        run('cd {{release_path}} && {{bin/composer}} show richardhj/contao-backup-manager');
     } catch (RuntimeException $e) {
         writeln("\r\033[1A\033[32C … skipped");
 
@@ -23,7 +23,7 @@ task('database:backup', function () {
         return;
     }
 
-    run('{{bin/php}} {{bin/console}} backup-manager:backup production local {{console_options}}');
+        run(sprintf('{{bin/php}} {{bin/console}} backup-manager:backup contao local -c gzip --filename %s.sql', date('Y-m-d-H-i-s')));
 })->desc('Backup database');
 
 // Migrate database

--- a/recipe/database.php
+++ b/recipe/database.php
@@ -10,6 +10,8 @@ use Deployer\Exception\RuntimeException;
  * ===============================================================
  */
 
+add('shared_dirs', ['backups']);
+
 // Backup database
 task('database:backup', function () {
     try {

--- a/recipe/database.php
+++ b/recipe/database.php
@@ -10,8 +10,6 @@ use Deployer\Exception\RuntimeException;
  * ===============================================================
  */
 
-add('shared_dirs', ['backups']);
-
 // Backup database
 task('database:backup', function () {
     try {


### PR DESCRIPTION
I switched to https://github.com/richardhj/contao-backup-manager which is compatible with your backup_manager configuration.

WIP:
- [x] `add('shared_dirs', ['backups'])`
- [ ] Create a command (i.e. `contao:backups:purge`) that purges old backups after 2 weeks or so
